### PR TITLE
Attribute set import

### DIFF
--- a/magmi/plugins/5b5/general/attributesetimport/attributesetimport.php
+++ b/magmi/plugins/5b5/general/attributesetimport/attributesetimport.php
@@ -68,6 +68,8 @@ class AttributeSetImporter extends Magmi_GeneralImportPlugin
                                     'valueSeparator' => ':',
                                     'columnNames' => array(
                                             'attribute_group_name',
+                                            'attribute_group_code',
+                                            'tab_group_code',
                                             'default_group_id',
                                             'sort_order'
                                     ),


### PR DESCRIPTION
In Magento 2.*.* we have a new two columns - 'tab_group_code', and 'default_group_id'. Without the tab_group_code, no attribute sets are created. These changes allow you to create attribute sets. In the csv file in the column "magmi:groups" we can write for example:
attribute_set_name,magmi:groups
New_Attribute_Set,"Product Details:product-details,New_Attribute_Set:new-attribute-set,Content:content,Bundle Items:bundle-items,Images:images,Search Engine Optimization:search-engine-optimization,Advanced Pricing:advanced-pricing,Design:design,Schedule Design Update:schedule-design-update,Autosettings:autosettings,Gift Options:gift-options"
Additional we can set other parameters in column "magmi:groups" for all attribute groups:
"New_Attribute_Set:new-attribute-set:basic:2:1"
Where:
"New_Attribute_Set" is 'attribute_group_name';
"new-attribute-set" is 'attribute_group_code';
"basic" is 'tab_group_code';
"2" is 'default_group_id';
"1" is 'sort_order'.