### PR TITLE
Fix for issue #24

### DIFF
--- a/magmi/engines/magmi_productimportengine.php
+++ b/magmi/engines/magmi_productimportengine.php
@@ -330,7 +330,7 @@ class Magmi_ProductImportEngine extends Magmi_Engine
         $bt = $attrinf['backend_type'];
         $user = $attrinf['is_user_defined'];
         //checking specific extension custom model for selects that might not respect magento default model
-        if ($user == 1 && $bt == 'int' && $finp == 'select' && isset($smodel) && $smodel != "eav/entity_attribute_source_table")
+        if ($user == 1 && $bt == 'int' && $finp == 'select' && isset($smodel) && $smodel != "eav/entity_attribute_source_table" && $smodel != "Magento\Eav\Model\Entity\Attribute\Source\Table")
         {
             $this->log("Potential assignment problem, specific model found for select attribute => " . $attrinf['attribute_code'] . "($smodel)", "warning");
         }


### PR DESCRIPTION
When adding configurable products Magmi would throw a error because the magmi code was still checking for the old model eav/entity_attribute_source_table instead of Magento\Eav\Model\Entity\Attribute\Source\Table

I have added the new model instead of replacing it, perhaps its possible to remove it all together but I didn't test this.