### PR TITLE
Workaround for trace infinity loop in exception handling

### DIFF
--- a/magmi/inc/magmi_engine.php
+++ b/magmi/inc/magmi_engine.php
@@ -409,7 +409,7 @@ abstract class Magmi_Engine extends DbHelper
                 }
             }
             // simple max trace depth fix
-            if (++$counter % 20 == 0) {
+            if (++$counter % 20 === 0) {
                 break;
             }
         }

--- a/magmi/inc/magmi_engine.php
+++ b/magmi/inc/magmi_engine.php
@@ -390,10 +390,11 @@ abstract class Magmi_Engine extends DbHelper
     {
         $this->_excid++;
         $trstr = "";
-        //FIXME: infinity loop in M2
+        //todo: improve infinity loop handling in M2
+        $counter = 0;
         foreach ($traces as $trace) {
             if (isset($trace["file"])) {
-                $fname = str_replace(dirname(dirname(__FILE__)), "", $trace["file"]);
+                $fname = str_replace(dirname(__DIR__), "", $trace["file"]);
                 $trstr .= $fname . ":" . (isset($trace["line"]) ? $trace["line"] : "?") . " - ";
                 if (isset($trace["class"])) {
                     $trstr .= $trace["class"] . "->";
@@ -406,6 +407,10 @@ abstract class Magmi_Engine extends DbHelper
                     }
                     $trstr .= "\n";
                 }
+            }
+            // simple max trace depth fix
+            if (++$counter % 20) {
+                break;
             }
         }
         if (!isset($this->_exceptions[$tk])) {

--- a/magmi/inc/magmi_engine.php
+++ b/magmi/inc/magmi_engine.php
@@ -394,7 +394,7 @@ abstract class Magmi_Engine extends DbHelper
         $counter = 0;
         foreach ($traces as $trace) {
             if (isset($trace["file"])) {
-                $fname = str_replace(dirname(__DIR__), "", $trace["file"]);
+                $fname = str_replace(dirname(dirname(__FILE__)), "", $trace["file"]);
                 $trstr .= $fname . ":" . (isset($trace["line"]) ? $trace["line"] : "?") . " - ";
                 if (isset($trace["class"])) {
                     $trstr .= $trace["class"] . "->";

--- a/magmi/inc/magmi_engine.php
+++ b/magmi/inc/magmi_engine.php
@@ -409,7 +409,7 @@ abstract class Magmi_Engine extends DbHelper
                 }
             }
             // simple max trace depth fix
-            if (++$counter % 20) {
+            if (++$counter % 20 == 0) {
                 break;
             }
         }


### PR DESCRIPTION
I copied the workaround from #54 because the pr is not yet splitted and i needed the functionality.