### PR TITLE
Fix error on not existing username

### DIFF
--- a/magmi/inc/magmi_auth.php
+++ b/magmi/inc/magmi_auth.php
@@ -35,7 +35,7 @@ class Magmi_Auth extends Magmi_Engine {
 		if (!$this->_hasDB) return ($this->user == 'magmi' && $this->pass == 'magmi');
 		$tn=$this->tablename('admin_user');
         $result = $this->select("SELECT * FROM $tn WHERE username = ?",array($this->user))->fetch(PDO::FETCH_ASSOC);
-        return $this->validatePass($result['password'],$this->pass);
+        return $result && $this->validatePass($result['password'],$this->pass);
     }
     
     private function validatePass($hash,$pass){


### PR DESCRIPTION
When trying to log in with an established database connection and wrong username, magmi throws an error because $result is empty.