### PR TITLE
Fix warning in php7: count on null in options importer

### DIFF
--- a/magmi/plugins/extra/itemprocessors/customoptions/pablo_customoptions.php
+++ b/magmi/plugins/extra/itemprocessors/customoptions/pablo_customoptions.php
@@ -121,7 +121,7 @@ class CustomOptionsItemProcessor extends Magmi_ItemProcessor
         $cvalarr = count($valarr);
         for ($i = 0; $i < $cvalarr; $i++) {
             $val = $valarr[$i];
-            if ($i < count($optionTypeIds)) {
+            if ($optionTypeIds && $i < count($optionTypeIds)) {
                 $optionTypeId = $optionTypeIds[$i];
             } else {
                 $sql = "INSERT INTO $t4

--- a/magmi/plugins/extra/itemprocessors/customoptions/pablo_customoptions.php
+++ b/magmi/plugins/extra/itemprocessors/customoptions/pablo_customoptions.php
@@ -36,7 +36,7 @@ class CustomOptionsItemProcessor extends Magmi_ItemProcessor
 
     public function getOptTypeIds($field)
     {
-        return isset($this->_opttypeids[$field]) ? $this->_opttypeids[$field] : null;
+        return isset($this->_opttypeids[$field]) ? $this->_opttypeids[$field] : [];
     }
 
     public function setOptTypeIds($field, $arr)
@@ -121,7 +121,7 @@ class CustomOptionsItemProcessor extends Magmi_ItemProcessor
         $cvalarr = count($valarr);
         for ($i = 0; $i < $cvalarr; $i++) {
             $val = $valarr[$i];
-            if ($optionTypeIds && $i < count($optionTypeIds)) {
+            if ($i < count($optionTypeIds)) {
                 $optionTypeId = $optionTypeIds[$i];
             } else {
                 $sql = "INSERT INTO $t4


### PR DESCRIPTION
Fixes: Warning: count(): Parameter must be an array or an object that implements Countable in vendor/macopedia/magmi2/magmi/plugins/extra/itemprocessors/customoptions/pablo_customoptions.php on line 124